### PR TITLE
Fix roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Quivr, your second brain, utilizes the power of GenerativeAI to store and retrieve unstructured information. Think of it as Obsidian, but turbocharged with AI capabilities.
 
-[Roadmap here](https://brain.quivr.app)
+[Roadmap here](https://brain.quivr.app/docs/roadmap)
 
 ## Key Features 🎯
 


### PR DESCRIPTION
Just simply replacing the old roadmap link that redirects to brain.quivr.app and instead fully redirect it to the full roadmap link at https://brain.quivr.app/docs/roadmap :)
